### PR TITLE
Neo4j 4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Graylog Neo4jOutput Plugin (Experimental)
 
 **Required Graylog version:** 2.0 and later
+**Required Neo4j version:** 3.5 and later
+
+Breaking changes between version 2.3 and 4.0
+--------------------------------------------
+
+* 4.0 is only compatible with Neo4j 3.5+
+* The HTTP url format changed (they are different between Neo4j 3.5 and Neo4j 4.x)
+* The query parameters now uses Neo4j standard format `$paramName` 
+
+Limitations: 
+* does not support neo4j native types in query parameters (number, dates, booleans). 
+The parameters have to be converted into the correct type if needed using cypher functions.
+* no multiple database support
 
 Installation
 ------------
@@ -21,3 +34,20 @@ This project is using Maven and requires Java 8 or higher.
 * Optional: Run `mvn jdeb:jdeb` and `mvn rpm:rpm` to create a DEB and RPM package respectively.
 * Copy generated JAR file in target directory to your Graylog plugin directory.
 * Restart the Graylog.
+
+Testing in a graylog instance
+-----------------------------
+
+* Build the plugin jar using `mvn package -DskipTests`
+* Start the graylog and databases with `docker-compose up`
+* Configure the plugin. See `test.http` or do it manually:
+    - connect to http://localhost:9000/system/outputs
+    - create a neo4j output
+    - connect to http://localhost:9000/streams/000000000000000000000001/outputs
+    - assign the neo4j output to the All message stream
+    - create a new GELF HTTP input here http://localhost:9000/system/inputs
+* Send some test data
+  
+    `curl -XPOST http://localhost:12201/gelf -p0 -d '{"short_message":"Hello there", "host":"example.org", "facility":"test", "source":"1.2.3.4", "user_id":"foo"}'`
+
+* Check the nodes are created with correct properties in Neo4j

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '2'
+services:
+  # MongoDB: https://hub.docker.com/_/mongo/
+  mongodb:
+    image: mongo:3
+  neo4j:
+    image: 'neo4j:4.2.2'
+    environment:
+      - NEO4J_AUTH=neo4j/password
+    ports:
+      - 7474:7474
+      - 7687:7687
+  # Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/docker.html
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=localhost
+      - network.host=0.0.0.0
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+  # Graylog: https://hub.docker.com/r/graylog/graylog/
+  graylog:
+    image: graylog/graylog:2.5
+    environment:
+      # CHANGE ME (must be at least 16 characters)!
+      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
+      # Password: admin
+      - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+      - GRAYLOG_WEB_ENDPOINT_URI=http://127.0.0.1:9000/api
+    links:
+      - mongodb:mongo
+      - elasticsearch
+      - neo4j
+    depends_on:
+      - mongodb
+      - elasticsearch
+      - neo4j
+    ports:
+      # Graylog web interface and REST API
+      - 9000:9000
+      # Syslog TCP
+      - 514:514
+      # Syslog UDP
+      - 514:514/udp
+      # GELF TCP
+      - 12201:12201
+      # GELF UDP
+      - 12201:12201/udp
+    volumes:
+      # Mount local plugin file into Docker container
+      - ./target/plugin-output-neo4j-4.0.0-SNAPSHOT.jar:/usr/share/graylog/plugin/plugin-output-neo4j-4.0.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>plugin-output-neo4j</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -15,9 +15,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <graylog2.version>2.3.0</graylog2.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <graylog2.version>2.5.1</graylog2.version>
         <graylog2.plugin-dir>/usr/share/graylog-server/plugin</graylog2.plugin-dir>
     </properties>
 
@@ -27,6 +27,12 @@
             <artifactId>graylog2-server</artifactId>
             <version>${graylog2.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -51,12 +57,23 @@
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
-            <version>1.4.3</version>
+            <!-- Compatible with all supported Neo4j version (3.5+ atm) -->
+            <version>4.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin> <!-- Required to get the tests running -->
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/Neo4jOutput.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/Neo4jOutput.java
@@ -3,6 +3,10 @@ package org.graylog.plugins.outputs.neo4j;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.graylog.plugins.outputs.neo4j.transport.INeo4jTransport;
 import org.graylog.plugins.outputs.neo4j.transport.Neo4jTransports;
 import org.graylog2.plugin.Message;
@@ -16,10 +20,6 @@ import org.graylog2.plugin.outputs.MessageOutputConfigurationException;
 import org.graylog2.plugin.streams.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Neo4jOutput implements MessageOutput {
     private static final Logger LOG = LoggerFactory.getLogger(Neo4jOutput.class);
@@ -114,8 +114,10 @@ public class Neo4jOutput implements MessageOutput {
                             ConfigurationField.Optional.NOT_OPTIONAL));
 
             configurationRequest.addField(new TextField(
-                            CK_NEO4J_URL, "Neo4j URL", "http://localhost:7474/db/data",
-                            "default for Bolt: bolt://localhost:7687/",
+                            CK_NEO4J_URL, "Neo4j URL", "http://localhost:7474/db/neo4j/tx/commit",
+                            "HTTP URL format for Neo4j 3.5.x: http://localhost:7474/db/data/transaction/commit\n"
+                                    + "HTTP URL format for Neo4j 4.x: http://localhost:7474/db/<dbName>/tx/commit\n"
+                                    + "Bolt URL format: bolt://localhost:7687/",
                             ConfigurationField.Optional.NOT_OPTIONAL)
             );
 
@@ -127,11 +129,11 @@ public class Neo4jOutput implements MessageOutput {
 
             configurationRequest.addField(new TextField(
                             CK_NEO4J_QUERY, "Cypher query",
-                            "MERGE (source:HOST { address: '${source}' })\n" +
-                                    "MERGE (user_id:USER { user_id: '${user_id}'})\nMERGE (source)-[:CONNECT]->(user_id)",
+                            "MERGE (source:HOST { address: $source })\n" +
+                                    "MERGE (user_id:USER { user_id: $user_id})\nMERGE (source)-[:CONNECT]->(user_id)",
                             "Query will be executed on every log message.\n" +
-                                    "HTTP Mode: Use template substitutions to access message fields: ${took_ms}\n" +
-                                    "Bolt Mode: Use curly brackets only to access message fields: {took_ms}",
+                                    "Queries use template substitutions to access message fields using default neo4j parameter syntax: $parameterName.\n" +
+                                    "All parameters are sent to the database as strings.",
                             ConfigurationField.Optional.NOT_OPTIONAL, TextField.Attribute.TEXTAREA)
             );
 

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/Neo4jOutput.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/Neo4jOutput.java
@@ -24,9 +24,8 @@ import org.slf4j.LoggerFactory;
 public class Neo4jOutput implements MessageOutput {
     private static final Logger LOG = LoggerFactory.getLogger(Neo4jOutput.class);
 
-    private Configuration configuration;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
-    private INeo4jTransport transport;
+    private final INeo4jTransport transport;
 
     public static final String CK_PROTOCOL = "neo4j_protocol";
     public static final String CK_NEO4J_URL = "neo4j_url";
@@ -37,9 +36,8 @@ public class Neo4jOutput implements MessageOutput {
 
     @Inject
     public Neo4jOutput(@Assisted Stream stream, @Assisted Configuration config) throws MessageOutputConfigurationException {
-        configuration = config;
-        final Neo4jTransports transportSelection;
-        switch (configuration.getString(CK_PROTOCOL).toUpperCase(Locale.ENGLISH)) {
+        Neo4jTransports transportSelection;
+        switch (config.getString(CK_PROTOCOL).toUpperCase(Locale.ENGLISH)) {
             case "BOLT":
                 transportSelection = Neo4jTransports.BOLT;
                 break;
@@ -48,11 +46,11 @@ public class Neo4jOutput implements MessageOutput {
                 break;
 
             default:
-                throw new MessageOutputConfigurationException("Unknown protocol " + configuration.getString(CK_PROTOCOL));
+                throw new MessageOutputConfigurationException("Unknown protocol " + config.getString(CK_PROTOCOL));
         }
 
         try {
-            transport = Neo4jTransports.create(transportSelection, configuration);
+            transport = Neo4jTransports.create(transportSelection, config);
         } catch (Exception e) {
             final String error = "Error initializing " + INeo4jTransport.class;
             LOG.error(error, e);

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/Neo4jStatement.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/Neo4jStatement.java
@@ -1,0 +1,44 @@
+package org.graylog.plugins.outputs.neo4j;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Neo4jStatement {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Neo4jStatement.class);
+	private static final Pattern CYPHER_PARAMETER_REGEX = Pattern.compile("\\$([a-zA-Z0-9_]+)");
+
+	private final String statement;
+	private final Collection<String> parameterNames;
+
+	public Neo4jStatement(String statement) {
+		this.statement = statement;
+		Matcher m = CYPHER_PARAMETER_REGEX.matcher(statement);
+		parameterNames = Collections.unmodifiableSet(extractParameterNames(m));
+	}
+
+	public String sanitizedQuery() {
+		return statement.replace("\n", " ")
+				.replace("\r", " ");
+	}
+
+	public Collection<String> parameterNames() {
+		return parameterNames;
+	}
+
+	private Set<String> extractParameterNames(Matcher m) {
+		Set<String> params = new HashSet<>();
+		while (m.find()) {
+			params.add(m.group(1));
+			LOG.debug("Found field in cypher statement: " + m.group(1));
+		}
+		LOG.info("Identified " + params.size() + " fields in graph create query.");
+		return params;
+	}
+}

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/transport/AbstractNeo4jTransport.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/transport/AbstractNeo4jTransport.java
@@ -1,0 +1,44 @@
+package org.graylog.plugins.outputs.neo4j.transport;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.graylog.plugins.outputs.neo4j.Neo4jStatement;
+import org.graylog2.plugin.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractNeo4jTransport  implements INeo4jTransport {
+
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractNeo4jTransport.class);
+
+	private final Neo4jStatement statement;
+
+	public AbstractNeo4jTransport(Neo4jStatement statement) {
+		this.statement = statement;
+	}
+
+
+	@Override
+	public void send(Message message) {
+
+		Collection<String> missingFieldNames = statement.parameterNames().stream()
+				.filter(it -> !message.hasField(it))
+				.collect(Collectors.toSet());
+		if (!missingFieldNames.isEmpty()) {
+			LOG.warn("Unable to execute query because of missing parameters in context : {}", missingFieldNames);
+			return;
+		}
+
+		Map<String, Object> convertedFields = message.getFields().entrySet().stream()
+				.filter(it -> statement.parameterNames().contains(it.getKey()))
+				.collect(toMap(Entry::getKey, it -> String.valueOf(it.getValue())));
+
+		postQuery(statement.sanitizedQuery(), convertedFields);
+	}
+
+	protected abstract void postQuery(String queryString, Map<String, Object> parameters);
+}

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/transport/INeo4jTransport.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/transport/INeo4jTransport.java
@@ -14,7 +14,7 @@ public interface INeo4jTransport {
      * @param message message to send to the remote host
      * @throws InterruptedException
      */
-    public void send(Message message) throws InterruptedException;
+    void send(Message message) throws InterruptedException;
 
     /**
      * Tries to send the given message to the remote host. It does <strong>not block</strong> if there is not enough
@@ -24,10 +24,10 @@ public interface INeo4jTransport {
      * @param message message to send to the remote host
      * @return true if the message could be dispatched, false otherwise
      */
-    public boolean trySend(Message message);
+    boolean trySend(Message message);
 
     /**
      * Stops the transport. Should be used to gracefully shutdown the backend.
      */
-    public void stop();
+    void stop();
 }

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/transport/Neo4JHttpTransport.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/transport/Neo4JHttpTransport.java
@@ -1,31 +1,33 @@
 package org.graylog.plugins.outputs.neo4j.transport;
 
-import com.floreysoft.jmte.Engine;
-import org.apache.commons.lang3.StringUtils;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.graylog.plugins.outputs.neo4j.Neo4jOutput;
-import org.graylog2.plugin.Message;
-import org.graylog2.plugin.configuration.Configuration;
-import org.graylog2.plugin.outputs.MessageOutputConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.*;
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.graylog.plugins.outputs.neo4j.Neo4jOutput;
+import org.graylog.plugins.outputs.neo4j.Neo4jStatement;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.outputs.MessageOutputConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by dev on 16/08/16.
  */
-public class Neo4JHttpTransport implements INeo4jTransport {
+public class Neo4JHttpTransport extends AbstractNeo4jTransport implements INeo4jTransport {
     private static final Logger LOG = LoggerFactory.getLogger(Neo4JHttpTransport.class);
 
     private WebTarget cypher;
@@ -33,11 +35,13 @@ public class Neo4JHttpTransport implements INeo4jTransport {
 
     public Neo4JHttpTransport(Configuration config) throws MessageOutputConfigurationException {
 
+        super(new Neo4jStatement(config.getString(Neo4jOutput.CK_NEO4J_QUERY)));
+
         this.configuration = config;
         URI databaseUri;
         try {
             URL baseUrl = new URL(configuration.getString(Neo4jOutput.CK_NEO4J_URL));
-            databaseUri = new URL(baseUrl, StringUtils.removeEnd(baseUrl.getPath(), "/") + "/transaction/commit").toURI();
+            databaseUri = new URL(baseUrl, StringUtils.removeEnd(baseUrl.getPath(), "/") + "").toURI();
         } catch (URISyntaxException e) {
             throw new MessageOutputConfigurationException("Syntax error in neo4j URL");
         } catch (MalformedURLException e) {
@@ -51,12 +55,14 @@ public class Neo4JHttpTransport implements INeo4jTransport {
         client.register(auth);
         cypher = client.target(databaseUri);
         if (!configuration.getString(Neo4jOutput.CK_NEO4J_STARTUP_QUERY).isEmpty()) {
-            postQuery(parseQuery(configuration.getString(Neo4jOutput.CK_NEO4J_STARTUP_QUERY)));
+            String queryString = new Neo4jStatement(configuration.getString(Neo4jOutput.CK_NEO4J_STARTUP_QUERY)).sanitizedQuery();
+            postQuery(queryString, Collections.emptyMap());
         }
     }
-    private void postQuery(List<HashMap<String, String>> queries) {
-        HashMap<String, List<HashMap<String, String>>> payload = new HashMap<>();
-        payload.put("statements", queries);
+
+    protected void postQuery(String query, Map<String, Object> parameters) {
+
+        Map<String, List<Map<String, Object>>> payload = buildPayload(query, parameters);
         Response response = cypher
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(payload, MediaType.APPLICATION_JSON), Response.class);
@@ -72,34 +78,24 @@ public class Neo4JHttpTransport implements INeo4jTransport {
         }
     }
 
-    private List<HashMap<String, String>> parseQuery(String queryString) {
-        List<HashMap<String, String>> query = new ArrayList<>();
+    private Map<String, List<Map<String, Object>>> buildPayload(String queryString, Map<String, Object> parameters) {
 
-        queryString = queryString.replace("\n", " ");
-        queryString = queryString.replace("\t", " ");
-        queryString = queryString.replace("\r", "");
-        queryString = queryString.replace(";", "");
+        // the JSON payload looks like
+//        {
+//            "statements" : [ {
+//                    "statement" : "MATCH (n) WHERE ID(n) = $nodeId RETURN n",
+//                    "parameters" : {
+//                      "nodeId" : 5
+//                    }
+//            } ]
+//        }
 
-        HashMap<String, String> statement = new HashMap<>();
-        statement.put("statement", queryString);
-        query.add(statement);
-
-        return query;
-    }
-
-    @Override
-    public void send(Message message) throws InterruptedException {
-        Iterator messageFields = message.getFields().entrySet().iterator();
-        Map<String, Object> model = new HashMap<>();
-        while (messageFields.hasNext()) {
-            Map.Entry pair = (Map.Entry) messageFields.next();
-            model.put(String.valueOf(pair.getKey()), String.valueOf(pair.getValue()));
-        }
-        Engine engine = new Engine();
-        String queryString = engine.transform(configuration.getString(Neo4jOutput.CK_NEO4J_QUERY), model);
-        List<HashMap<String, String>> query = parseQuery(queryString);
-
-        postQuery(query);
+        Map<String, Object> statementWithParameters = new HashMap<>();
+        statementWithParameters.put("statement", queryString);
+        statementWithParameters.put("parameters", parameters);
+        Map<String, List<Map<String, Object>>> payload = new HashMap<>();
+        payload.put("statements", Collections.singletonList(statementWithParameters));
+        return payload;
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/outputs/neo4j/transport/Neo4JHttpTransport.java
+++ b/src/main/java/org/graylog/plugins/outputs/neo4j/transport/Neo4JHttpTransport.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -30,8 +31,8 @@ import org.slf4j.LoggerFactory;
 public class Neo4JHttpTransport extends AbstractNeo4jTransport implements INeo4jTransport {
     private static final Logger LOG = LoggerFactory.getLogger(Neo4JHttpTransport.class);
 
-    private WebTarget cypher;
-    private Configuration configuration;
+    private final WebTarget cypher;
+    private final Configuration configuration;
 
     public Neo4JHttpTransport(Configuration config) throws MessageOutputConfigurationException {
 
@@ -40,7 +41,7 @@ public class Neo4JHttpTransport extends AbstractNeo4jTransport implements INeo4j
         this.configuration = config;
         URI databaseUri;
         try {
-            URL baseUrl = new URL(configuration.getString(Neo4jOutput.CK_NEO4J_URL));
+            URL baseUrl = new URL(Objects.requireNonNull(configuration.getString(Neo4jOutput.CK_NEO4J_URL)));
             databaseUri = new URL(baseUrl, StringUtils.removeEnd(baseUrl.getPath(), "/") + "").toURI();
         } catch (URISyntaxException e) {
             throw new MessageOutputConfigurationException("Syntax error in neo4j URL");
@@ -54,7 +55,8 @@ public class Neo4JHttpTransport extends AbstractNeo4jTransport implements INeo4j
         Client client = ClientBuilder.newClient();
         client.register(auth);
         cypher = client.target(databaseUri);
-        if (!configuration.getString(Neo4jOutput.CK_NEO4J_STARTUP_QUERY).isEmpty()) {
+        String startupQuery = configuration.getString(Neo4jOutput.CK_NEO4J_STARTUP_QUERY);
+        if (startupQuery != null && !startupQuery.isEmpty()) {
             String queryString = new Neo4jStatement(configuration.getString(Neo4jOutput.CK_NEO4J_STARTUP_QUERY)).sanitizedQuery();
             postQuery(queryString, Collections.emptyMap());
         }

--- a/src/test/java/org/graylog/plugins/outputs/neo4j/Neo4jStatementTest.java
+++ b/src/test/java/org/graylog/plugins/outputs/neo4j/Neo4jStatementTest.java
@@ -1,0 +1,45 @@
+package org.graylog.plugins.outputs.neo4j;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+
+class Neo4jStatementTest {
+
+	@Test
+	void shouldRemoveNewLine() {
+
+		Neo4jStatement statement = new Neo4jStatement("\n");
+		assertEquals(" ", statement.sanitizedQuery());
+	}
+
+	@Test
+	void shouldRemoveCarriageReturn() {
+
+		Neo4jStatement statement = new Neo4jStatement("\r");
+		assertEquals(" ", statement.sanitizedQuery());
+	}
+
+	@Test
+	void shouldExtractParameterNames() {
+
+		Neo4jStatement statement = new Neo4jStatement("blah");
+		assertEquals(0, statement.parameterNames().size());
+
+		statement = new Neo4jStatement("blah $foo");
+		assertEquals(1, statement.parameterNames().size());
+		assertEquals(Collections.singleton("foo"), statement.parameterNames());
+
+		statement = new Neo4jStatement("blah $foo $bar");
+		Collection<String> expected = new HashSet<>();
+		expected.add("foo");
+		expected.add("bar");
+		assertEquals(expected, statement.parameterNames());
+
+		statement = new Neo4jStatement("blah $foo_bar");
+		assertEquals("foo_bar", statement.parameterNames().iterator().next());
+	}
+}

--- a/src/test/java/org/graylog/plugins/outputs/neo4j/transport/AbstractNeo4jTransportTest.java
+++ b/src/test/java/org/graylog/plugins/outputs/neo4j/transport/AbstractNeo4jTransportTest.java
@@ -1,0 +1,51 @@
+package org.graylog.plugins.outputs.neo4j.transport;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.graylog.plugins.outputs.neo4j.Neo4jStatement;
+import org.graylog2.plugin.Message;
+import org.junit.jupiter.api.Test;
+
+class AbstractNeo4jTransportTest {
+
+	@Test
+	void shouldExecuteQueryWithValidArguments() {
+		Neo4jTransportStub transport = new Neo4jTransportStub(new Neo4jStatement("CREATE (t:Test {value:$value})"));
+		transport.send(new Message(ImmutableMap.of("_id", "id value", "value", "foo")));
+		assertTrue(transport.queryPosted);
+	}
+
+	@Test
+	void shouldNotExecuteQueryWithMissingArgument() {
+		Neo4jTransportStub transport = new Neo4jTransportStub(new Neo4jStatement("CREATE (t:Test {value:$value})"));
+		transport.send(new Message(ImmutableMap.of("_id", "id value")));
+		assertFalse(transport.queryPosted);
+	}
+
+	private static class Neo4jTransportStub extends AbstractNeo4jTransport {
+
+		boolean queryPosted = false;
+
+		public Neo4jTransportStub(Neo4jStatement statement) {
+			super(statement);
+		}
+
+		@Override
+		protected void postQuery(String queryString, Map<String, Object> parameters) {
+			queryPosted = true;
+		}
+
+		@Override
+		public boolean trySend(Message message) {
+			return false;
+		}
+
+		@Override
+		public void stop() {
+
+		}
+	}
+}

--- a/src/test/java/org/graylog/plugins/outputs/neo4j/transport/Neo4jTransportIntegrationTest.java
+++ b/src/test/java/org/graylog/plugins/outputs/neo4j/transport/Neo4jTransportIntegrationTest.java
@@ -1,0 +1,133 @@
+package org.graylog.plugins.outputs.neo4j.transport;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.graylog.plugins.outputs.neo4j.Neo4jOutput;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.outputs.MessageOutputConfigurationException;
+import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.graylog2.shared.bindings.RestApiBindings;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+
+// requires Neo4j running - a container can be run easily from the docker-compose file
+public class Neo4jTransportIntegrationTest {
+
+	private static final String NEO4J_USERNAME = "neo4j";
+	private static final String NEO4J_PASSWORD = "password";
+	private static final String NEO4J_URL = "bolt://localhost";
+	private static final String NEO4J_HTTP_URL = "http://localhost:7474/db/neo4j/tx/commit";
+	// For neo4j 3.5.x, use the URL syntax is different
+//	private static final String NEO4J_HTTP_URL = "http://localhost:7474/db/data/transaction/commit";
+	private static final String TEST_CYPHER_QUERY = "CREATE (n:Test {someKey:$someKeyValue}) RETURN n";
+
+	private final Driver neo4jDriver = GraphDatabase.driver(NEO4J_URL, AuthTokens.basic(NEO4J_USERNAME, NEO4J_PASSWORD));
+
+	@BeforeEach
+	void setUp() {
+		neo4jDriver.session().run("MATCH (n:Test) DELETE n").consume();
+	}
+
+	@ParameterizedTest
+	@ArgumentsSource(Neo4jTransportArgumentsProvider.class)
+	void shouldExecuteSimpleQuery(INeo4jTransport transport) throws InterruptedException {
+
+		Message message = new Message(ImmutableMap.of("_id", "id value", "someKeyValue", "foo"));
+
+		transport.send(message);
+
+		Record result = neo4jDriver.session().run("MATCH (n:Test) RETURN n").single();
+		Assertions.assertEquals("foo", result.get("n").asNode().get("someKey").asString());
+	}
+
+	@ParameterizedTest
+	@ArgumentsSource(Neo4jTransportArgumentsProvider.class)
+	void shouldNotCreateDataWhenMissingQueryParameter(INeo4jTransport transport) throws InterruptedException {
+
+		Message message = new Message(ImmutableMap.of("_id", "id value"));
+
+		transport.send(message);
+
+		Result result = neo4jDriver.session().run("MATCH (n:Test) RETURN n");
+		Assertions.assertFalse(result.hasNext());
+	}
+
+	@ParameterizedTest
+	@ArgumentsSource(Neo4jTransportArgumentsProvider.class)
+	void shouldAllowDateTimeDataInMessage(INeo4jTransport transport) throws InterruptedException {
+
+		DateTime now = DateTime.now();
+		Message message = new Message(ImmutableMap.of("_id", "id value", "someKeyValue", now));
+
+		transport.send(message);
+
+		Record result = neo4jDriver.session().run("MATCH (n:Test) RETURN n").single();
+		Assertions.assertEquals(now.toString(), result.get("n").asNode().get("someKey").asString());
+	}
+
+	static class Neo4jTransportArgumentsProvider implements ArgumentsProvider {
+
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+			Map<String, Object> configValues = new HashMap<>();
+			configValues.put(Neo4jOutput.CK_PROTOCOL, "bolt");
+			configValues.put(Neo4jOutput.CK_NEO4J_URL, NEO4J_URL);
+			configValues.put(Neo4jOutput.CK_NEO4J_USER, NEO4J_USERNAME);
+			configValues.put(Neo4jOutput.CK_NEO4J_PASSWORD, NEO4J_PASSWORD);
+			configValues.put(Neo4jOutput.CK_NEO4J_STARTUP_QUERY, "RETURN 1");
+			configValues.put(Neo4jOutput.CK_NEO4J_QUERY, TEST_CYPHER_QUERY);
+
+			Configuration configuration = new Configuration(configValues);
+			Neo4JBoltTransport boltTransport = getBoltTransport(configuration);
+
+			configValues.put(Neo4jOutput.CK_NEO4J_URL, NEO4J_HTTP_URL);
+			configuration = new Configuration(configValues);
+			Neo4JHttpTransport httpTransport = getHttpTransport(configuration);
+
+			return Stream.of(
+					Arguments.of(boltTransport),
+					Arguments.of(httpTransport)
+			);
+		}
+
+		private Neo4JHttpTransport getHttpTransport(Configuration configuration) {
+
+			// this is needed, otherwise the REST client init fails
+			GuiceInjectorHolder.createInjector(Collections.singletonList(new RestApiBindings()));
+
+			Neo4JHttpTransport httpTransport;
+			try {
+				httpTransport = new Neo4JHttpTransport(configuration);
+			} catch (MessageOutputConfigurationException e) {
+				throw new RuntimeException(e);
+			}
+			return httpTransport;
+		}
+
+		private Neo4JBoltTransport getBoltTransport(Configuration configuration) {
+			Neo4JBoltTransport boltTransport;
+			try {
+				boltTransport = new Neo4JBoltTransport(configuration);
+			} catch (MessageOutputConfigurationException e) {
+				throw new RuntimeException(e);
+			}
+			return boltTransport;
+		}
+	}
+}

--- a/test.http
+++ b/test.http
@@ -1,0 +1,85 @@
+
+### Create a Neo4j bolt output
+# curl 'http://127.0.0.1:9000/api/system/outputs' -H 'Accept: application/json' -H 'X-Requested-By: XMLHttpRequest' -H 'Authorization: Basic ZmJkMDM5NzAtZGQxMS00YzA0LThjYTUtOTY1NjhhYzIzNTNjOnNlc3Npb24=' -H 'Content-Type: application/json' --data-raw '{"title":"neo4j","type":"org.graylog.plugins.outputs.neo4j.Neo4jOutput","configuration":{"neo4j_protocol":"HTTP","neo4j_url":"http://localhost:7474/db/neo4j/tx/commit","neo4j_startup_query":"CREATE INDEX ON :HOST(address)","neo4j_query":"MERGE (source:HOST { address: $source })\nMERGE (user_id:USER { user_id: $user_id})\nMERGE (source)-[:CONNECT]->(user_id)","neo4j_user":"neo4j","neo4j_password":"qqq"}}'
+POST http://127.0.0.1:9000/api/system/outputs
+Accept: application/json
+Authorization: Basic admin admin
+Content-Type: application/json
+X-Requested-By: XMLHttpRequest
+
+{
+  "title": "neo4j",
+  "type": "org.graylog.plugins.outputs.neo4j.Neo4jOutput",
+  "configuration": {
+    "neo4j_protocol": "BOLT",
+    "neo4j_url": "bolt://neo4j:7687",
+    "neo4j_startup_query": "CREATE INDEX ON :HOST(address)",
+    "neo4j_query": "MERGE (source:HOST { address: $source }) MERGE (user_id:USER { user_id: $user_id}) MERGE (source)-[:CONNECT]->(user_id)",
+    "neo4j_user": "neo4j",
+    "neo4j_password": "password"
+  }
+}
+
+> {% client.global.set("output_id", response.body.id); %}
+
+### Add the ouput to the all messages stream
+# curl 'http://127.0.0.1:9000/api/streams/000000000000000000000001/outputs' -H 'X-Requested-By: XMLHttpRequest' -H 'Accept: application/json' -H 'Authorization: Basic ZmJkMDM5NzAtZGQxMS00YzA0LThjYTUtOTY1NjhhYzIzNTNjOnNlc3Npb24=' -H 'Content-Type: application/json' --data-raw '{"outputs":["60352c5b471afa000c0f4d15"]}'
+POST http://127.0.0.1:9000/api/streams/000000000000000000000001/outputs
+Accept: application/json
+Authorization: Basic admin admin
+Content-Type: application/json
+X-Requested-By: XMLHttpRequest
+
+{"outputs":["{{output_id}}"]}
+
+### Create a GELF HTTP input
+# curl 'http://127.0.0.1:9000/api/system/inputs' -H 'Accept: application/json' -H 'X-Requested-By: XMLHttpRequest' -H 'Authorization: Basic ZmJkMDM5NzAtZGQxMS00YzA0LThjYTUtOTY1NjhhYzIzNTNjOnNlc3Npb24=' -H 'Content-Type: application/json' --data-raw '{"title":"http input","type":"org.graylog2.inputs.gelf.http.GELFHttpInput","configuration":{"bind_address":"0.0.0.0","port":12201,"recv_buffer_size":1048576,"tls_cert_file":"","tls_key_file":"","tls_enable":false,"tls_key_password":"","tls_client_auth":"disabled","tls_client_auth_cert_file":"","tcp_keepalive":false,"enable_cors":true,"max_chunk_size":65536,"idle_writer_timeout":60,"override_source":null,"decompress_size_limit":8388608},"global":true}'
+POST http://127.0.0.1:9000/api/system/inputs
+Accept: application/json
+Accept-Language: en-US,en;q=0.5
+X-Requested-By: XMLHttpRequest
+Authorization: Basic admin admin
+Content-Type: application/json
+
+{
+  "title": "http input",
+  "type": "org.graylog2.inputs.gelf.http.GELFHttpInput",
+  "configuration": {
+    "bind_address": "0.0.0.0",
+    "port": 12201,
+    "recv_buffer_size": 1048576,
+    "tls_cert_file": "",
+    "tls_key_file": "",
+    "tls_enable": false,
+    "tls_key_password": "",
+    "tls_client_auth": "disabled",
+    "tls_client_auth_cert_file": "",
+    "tcp_keepalive": false,
+    "enable_cors": true,
+    "max_chunk_size": 65536,
+    "idle_writer_timeout": 60,
+    "override_source": null,
+    "decompress_size_limit": 8388608
+  },
+  "global": true
+}
+
+### Send some sample data
+# curl -XPOST http://localhost:12201/gelf  -d '{"short_message":"Hello there", "host":"example.org", "facility":"test", "source":"1.2.3.4", "user_id":"foo"}'
+POST http://localhost:12201/gelf
+Content-Type: application/x-www-form-urlencoded
+
+{"short_message":"Hello there", "host":"example.org", "facility":"test", "source":"1.2.3.4", "user_id":"foo"}
+
+### Check the data has been created into Neo4j (or just use the neo4j browser on http://localhost:7474
+
+POST http://localhost:7474/db/neo4j/tx/commit
+Content-Type: application/json
+Authorization: basic neo4j password
+
+{
+  "statements" : [ {
+    "statement" : "MATCH (n:USER) RETURN n"
+  } ]
+}
+


### PR DESCRIPTION
Add compatibility with Neo4j 3.5 and 4.x (which are the only currently supported versions)

- driver update and related API changes (previous driver was not compatible with deprecated
- change HTTP URL format
- change cypher query parameter format
- add unit and integration tests

The changes have been tested with Graylog 2.5, Neo4j 3.5 and 4.2, see README for a description on how to test